### PR TITLE
Update 0.1.5.0 - add new variable bShowPlayerList

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ If you want to support my work:
 | bUseAuth                                | USE_AUTH                                  |   |
 | BanListURL                              | BAN_LIST_URL                              |   |
 | Region                                  | SERVER_REGION                             |   |
+| bShowPlayerList                         | SHOW_PLAYER_LIST                          |   |
 
 
 # Notes

--- a/main.go
+++ b/main.go
@@ -116,6 +116,7 @@ func main() {
 		"bUseAuth":                             "USE_AUTH",
 		"BanListURL":                           "BAN_LIST_URL",
 		"Region":                               "SERVER_REGION",
+		"bShowPlayerList":			"SHOW_PLAYER_LIST",
 		// Add other environment variables and corresponding INI keys here
 	}
 
@@ -186,6 +187,7 @@ func main() {
 		"bUseAuth":                             "TrueFalse", //bUseAuth=True,
 		"BanListURL":                           "String",    //BanListURL="https://api.palworldgame.com/api/banlist.txt"
 		"Region":                               "String",    //Region="",
+		"bShowPlayerList":			"TrueFalse", //bShowPlayerList=False
 		// Add other keys as needed
 	}
 

--- a/main.go
+++ b/main.go
@@ -13,7 +13,7 @@ import (
 )
 
 // Version of the program
-const Version = "v1.0.10"
+const Version = "v1.0.11"
 
 func main() {
 	fmt.Println("Program Version:", Version)


### PR DESCRIPTION
With patch 0.1.5.0 they have added new config variable "bShowPlayerList" as boolean to toggle wether the player list should be appear ingame when pressed ESC or not.

NOTE: I currently do not know how this behaves with a existing config as the value has not been added to the config or example config either with the patch..

The new variable can be found at the docs: https://tech.palworldgame.com/settings-and-operation/configuration



Is it possible to automatically download the current config parser on startup, as it remains an older version if not updating it manually?