### PR TITLE
Add new config variables added in 0.2.0.6

### DIFF
--- a/main.go
+++ b/main.go
@@ -360,6 +360,11 @@ func setINIValue(content *[]byte, key, value string, addQuotes bool) {
 
 	// Update the content slice in place
 	*content = append((*content)[:start], append([]byte(value), (*content)[end:]...)...)
+
+	// Add back the closing bracket if it was removed
+    	if (*content)[len(*content)-1] != ')' {
+        	*content = append(*content, ')')
+    }
 }
 
 // copyFile copies a file from src to dst

--- a/main.go
+++ b/main.go
@@ -13,7 +13,7 @@ import (
 )
 
 // Version of the program
-const Version = "v1.0.12"
+const Version = "v1.0.13"
 
 func main() {
 	fmt.Println("Program Version:", Version)
@@ -117,6 +117,10 @@ func main() {
 		"BanListURL":                           "BAN_LIST_URL",
 		"Region":                               "SERVER_REGION",
 		"bShowPlayerList":                      "SHOW_PLAYER_LIST",
+		"RESTAPIEnabled":                      	"REST_API_ENABLED",
+		"RESTAPIPort":                      	"REST_API_PORT",
+		"AllowConnectPlatform":                 "ALLOW_CONNECT_PLATFORM",
+		"bIsUseBackupSaveData":                 "USE_BACKUP_SAVE_DATA",
 		// Add other environment variables and corresponding INI keys here
 	}
 
@@ -188,6 +192,10 @@ func main() {
 		"BanListURL":                           "String",    //BanListURL="https://api.palworldgame.com/api/banlist.txt"
 		"Region":                               "String",    //Region="",
 		"bShowPlayerList":                      "TrueFalse", //bShowPlayerList=False
+		"RESTAPIEnabled":                     	"TrueFalse", //RESTAPIEnabled=False
+		"RESTAPIPort":                      	"Numeric",   //RESTAPIPort=8212
+		"AllowConnectPlatform":                 "String",    //AllowConnectPlatform=Steam
+		"bIsUseBackupSaveData":                 "TrueFalse", //bIsUseBackupSaveData=True
 		// Add other keys as needed
 	}
 

--- a/main.go
+++ b/main.go
@@ -13,7 +13,7 @@ import (
 )
 
 // Version of the program
-const Version = "v1.0.11"
+const Version = "v1.0.12"
 
 func main() {
 	fmt.Println("Program Version:", Version)


### PR DESCRIPTION
Adding new config variables from patch 0.2.0.6

Regarding the official docu seems to be that some variables have been deleted but still exist in the DefaultPalWorldSettings.ini so i did not delete them yet.