### PR TITLE
Remove AllowConnectPlatform from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,6 @@ If you want to support my work:
 | bShowPlayerList                         | SHOW_PLAYER_LIST                          |                   |
 | RESTAPIEnabled                          | REST_API_ENABLED                          |                   |
 | RESTAPIPort                             | REST_API_PORT                             |                   |
-| AllowConnectPlatform                    | ALLOW_CONNECT_PLATFORM                    |                   |
 | bIsUseBackupSaveData                    | USE_BACKUP_SAVE_DATA                      |                   |
 | LogFormatType                           | LOG_FORMAT_TYPE                           |                   |
 | SupplyDropSpan                          | SUPPLY_DROP_SPAN                          |                   |


### PR DESCRIPTION
AllowConnectPlatform has been removed in ebafff2 from the parser, but it is still listed in the README.
This PR updates the README to reflect the change.